### PR TITLE
DRAFT tool: defra-kv -- key-value store via defradb embedded in CLI tool

### DIFF
--- a/defra-kv.go
+++ b/defra-kv.go
@@ -1,0 +1,175 @@
+// main.go
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	dclient "github.com/sourcenetwork/defradb/client"
+	dnode   "github.com/sourcenetwork/defradb/node"
+)
+
+func defaultRootdir() string {
+	if cwd, err := os.Getwd(); err == nil {
+		return filepath.Join(cwd, ".defra-kv")
+	}
+	return ".defra-kv"
+}
+
+func expandHome(p string) string {
+	if strings.HasPrefix(p, "~/") {
+		if h, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(h, p[2:])
+		}
+	}
+	return p
+}
+
+func resolveRootdir(p string) string {
+	p = expandHome(p)
+	if !filepath.IsAbs(p) {
+		if abs, err := filepath.Abs(p); err == nil {
+			p = abs
+		}
+	}
+	if err := os.MkdirAll(p, 0o755); err != nil {
+		log.Fatalf("create rootdir: %v", err)
+	}
+	return p
+}
+
+// Single JSON-based KV schema with indexes where useful.
+const kvSchema = `
+type KV {
+  key: String @index
+  value: JSON
+  updatedAt: DateTime @index
+}
+`
+
+func kvExists(ctx context.Context, n *dnode.Node) bool {
+	res := n.DB.ExecRequest(ctx, `query { __type(name: "KV") { name } }`)
+	if len(res.GQL.Errors) > 0 {
+		return false
+	}
+	b, err := json.Marshal(res.GQL.Data)
+	if err != nil {
+		return false
+	}
+	return bytes.Contains(b, []byte(`"name":"KV"`))
+}
+
+func ensureKV(ctx context.Context, n *dnode.Node) error {
+	if kvExists(ctx, n) {
+		return nil
+	}
+	if _, err := n.DB.AddSchema(ctx, kvSchema); err != nil {
+		return fmt.Errorf("KV schema add failed: %v", err)
+	}
+	return nil
+}
+
+func main() {
+	// ---- Custom FlagSet (avoid random flags from transitive deps) ----
+	fs := flag.NewFlagSet("defra-kv", flag.ExitOnError)
+	rootdir := fs.String("rootdir", defaultRootdir(), "data/config directory (default: ./.defra-kv)")
+	secret  := fs.String("keyring-secret", "", "keyring secret (or set DEFRA_KEYRING_SECRET)")
+	query   := fs.String("query", "", "GraphQL query/mutation; if empty, read from stdin")
+	varsStr := fs.String("vars", "", "JSON variables (optional)")
+	pretty  := fs.Bool("pretty", true, "pretty-print JSON")
+	reqTO   := fs.Duration("timeout", 10*time.Second, "per-request timeout")
+	_ = fs.Parse(os.Args[1:])
+
+	// Keyring secret (first run convenience).
+	if *secret != "" {
+		_ = os.Setenv("DEFRA_KEYRING_SECRET", *secret)
+	}
+	if os.Getenv("DEFRA_KEYRING_SECRET") == "" {
+		_ = os.Setenv("DEFRA_KEYRING_SECRET", "dev-dev-dev")
+	}
+
+	// Read query (flag or stdin).
+	q := strings.TrimSpace(*query)
+	if q == "" {
+		b, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			log.Fatalf("read stdin: %v", err)
+		}
+		q = strings.TrimSpace(string(b))
+	}
+	if q == "" {
+		fmt.Fprintln(os.Stderr, "no query provided; pass --query or pipe to stdin")
+		os.Exit(2)
+	}
+
+	// Variables (optional, parsed later).
+	var rawVars json.RawMessage
+	if v := strings.TrimSpace(*varsStr); v != "" {
+		rawVars = json.RawMessage(v)
+	}
+
+	// Context + signals.
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	// --- 1) Create the node (embedded, persistent Badger) ---
+	n, err := dnode.New(
+		ctx,
+		dnode.WithDisableAPI(true),                    // no HTTP server
+		dnode.WithDisableP2P(true),                    // local only
+		dnode.WithBadgerInMemory(false),               // persistent
+		dnode.WithStoreType(dnode.BadgerStore),
+		dnode.WithStorePath(resolveRootdir(*rootdir)), // data dir
+		dnode.WithLensRuntime(dnode.Wazero),           // pure-Go WASM runtime
+	)
+	if err != nil {
+		log.Fatalf("node.New: %v", err)
+	}
+	defer func() { _ = n.Close(ctx) }()
+	if err := n.Start(ctx); err != nil {
+		log.Fatalf("node.Start: %v", err)
+	}
+
+	// --- 2) Ensure KV schema (idempotent) ---
+	if err := ensureKV(ctx, n); err != nil {
+		log.Fatalf("ensure KV schema: %v", err)
+	}
+
+	// --- 3) Execute the user’s GraphQL directly in-process ---
+	var vars map[string]any
+	if len(rawVars) > 0 {
+		if err := json.Unmarshal(rawVars, &vars); err != nil {
+			log.Fatalf("parse -vars: %v", err)
+		}
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, *reqTO)
+	defer cancel()
+
+	res := n.DB.ExecRequest(reqCtx, q, dclient.WithVariables(vars))
+	if len(res.GQL.Errors) > 0 {
+		enc, _ := json.MarshalIndent(res.GQL.Errors, "", "  ")
+		fmt.Fprintln(os.Stderr, string(enc))
+		os.Exit(1)
+	}
+
+	// Output JSON (pretty or compact).
+	if *pretty {
+		out, _ := json.MarshalIndent(map[string]any{"data": res.GQL.Data}, "", "  ")
+		fmt.Println(string(out))
+	} else {
+		out, _ := json.Marshal(map[string]any{"data": res.GQL.Data})
+		fmt.Println(string(out))
+	}
+}

--- a/defra-kv.go
+++ b/defra-kv.go
@@ -52,9 +52,9 @@ func resolveRootdir(p string) string {
 // Single JSON-based KV schema with indexes where useful.
 const kvSchema = `
 type KV {
-  key: String @index
-  value: JSON
-  updatedAt: DateTime @index
+	key: String @index(unique: true)
+	value: JSON
+	updatedAt: DateTime @index
 }
 `
 
@@ -107,6 +107,25 @@ func (s *fdSilencer) Mute() {
 	log.SetOutput(dn)
 
 	s.muted = true
+}
+
+func (s *fdSilencer) Restore() {
+	if !s.muted {
+		return
+	}
+	if s.origLogWriter != nil {
+		log.SetOutput(s.origLogWriter)
+	}
+	if s.origStdout != nil {
+		os.Stdout = s.origStdout
+	}
+	if s.origStderr != nil {
+		os.Stderr = s.origStderr
+	}
+	if s.devnull != nil {
+		_ = s.devnull.Close()
+	}
+	s.muted = false
 }
 
 func (s *fdSilencer) PrintlnOut(line string) {

--- a/defra-kv.go
+++ b/defra-kv.go
@@ -128,52 +128,6 @@ func die(s *fdSilencer, format string, a ...any) {
 	os.Exit(1)
 }
 
-// Convert a Go value (from JSON) into a GraphQL input literal string.
-// Supports: nil, bool, finite numbers, strings, arrays, and objects with GraphQL-Name keys.
-func toGraphQLLiteral(v any) (string, error) {
-	if v == nil {
-		return "null", nil
-	}
-	switch t := v.(type) {
-	case string:
-		b, _ := json.Marshal(t)
-		return string(b), nil
-	case bool:
-		if t {
-			return "true", nil
-		}
-		return "false", nil
-	case float64:
-		// JSON numbers decode to float64 and are finite by spec.
-		return fmt.Sprintf("%v", t), nil
-	case []any:
-		parts := make([]string, 0, len(t))
-		for _, e := range t {
-			lit, err := toGraphQLLiteral(e)
-			if err != nil {
-				return "", err
-			}
-			parts = append(parts, lit)
-		}
-		return "[" + strings.Join(parts, ", ") + "]", nil
-	case map[string]any:
-		parts := make([]string, 0, len(t))
-		for k, val := range t {
-			if !gqlNameRE.MatchString(k) {
-				return "", fmt.Errorf("invalid GraphQL key: %q", k)
-			}
-			lit, err := toGraphQLLiteral(val)
-			if err != nil {
-				return "", err
-			}
-			parts = append(parts, k+": "+lit)
-		}
-		return "{ " + strings.Join(parts, ", ") + " }", nil
-	default:
-		return "", fmt.Errorf("unsupported type in literal: %T", v)
-	}
-}
-
 func main() {
 	// Flags
 	fs := flag.NewFlagSet("defra-kv", flag.ExitOnError)
@@ -297,34 +251,15 @@ func main() {
 			now := time.Now().UTC().Format(time.RFC3339Nano)
 			vars["now"] = now
 			vars["key"] = *setKey
+			vars["value"] = val
 
-			// Note: this style (passing in `value` as an external variable)
-			// does not currently work, due to a bug in defra
-			//
-			// vars["value"] = val
-			// q = `mutation setKV($key:String!,$value:JSON!,$now:DateTime!) {
-			// 	upsert_KV(
-			// 		filter: { key: { _eq: $key } }
-			// 		create: { key: $key, value: $value, updatedAt: $now }
-			// 		update: { value: $value, updatedAt: $now }
-			// 	) { _docID }
-			// }`
-
-			lit, err := toGraphQLLiteral(val)
-			if err != nil {
-				die(&sil, "value cannot be inlined: %v", err)
-			}
-			q = fmt.Sprintf(
-				`mutation setKV($key:String!,$now:DateTime!) {
-					upsert_KV(
-						filter: { key: { _eq: $key } }
-						create: { key: $key, value: %s, updatedAt: $now }
-						update: { value: %s, updatedAt: $now }
-					) { _docID }
-				}`,
-				lit,
-				lit,
-			)
+			q = `mutation setKV($key:String!,$value:JSON!,$now:DateTime!) {
+				upsert_KV(
+					filter: { key: { _eq: $key } }
+					create: { key: $key, value: $value, updatedAt: $now }
+					update: { value: $value, updatedAt: $now }
+				) { _docID }
+			}`
 		} else if *getKey != "" {
 			vars["key"] = *getKey
 			q = "query getKV($key:String!) { KV(filter:{ key:{ _eq:$key } }) { key value } }"

--- a/defra-kv.go
+++ b/defra-kv.go
@@ -215,9 +215,6 @@ func main() {
 	if err != nil {
 		die(&sil, "dnode.New: %v", err)
 	}
-	defer func() {
-		_ = n.Close(ctx)
-	}()
 
 	if err := n.Start(ctx); err != nil {
 		die(&sil, "n.Start: %v", err)

--- a/defra-kv.go
+++ b/defra-kv.go
@@ -44,7 +44,7 @@ func resolveRootdir(p string) string {
 		}
 	}
 	if err := os.MkdirAll(p, 0o755); err != nil {
-		log.Fatalf("create rootdir: %v", err)
+		log.Fatalf("create dataConfigDir: %v", err)
 	}
 	return p
 }
@@ -140,13 +140,13 @@ func die(s *fdSilencer, format string, a ...any) {
 func main() {
 	// Flags
 	fs := flag.NewFlagSet("defra-kv", flag.ExitOnError)
-	rootdir := fs.String("rootdir", defaultRootdir(), "Data/config directory")
-	secret  := fs.String("keyring-secret", "", "Keyring secret (sets DEFRA_KEYRING_SECRET)")
-	query   := fs.String("query", "", "GraphQL query/mutation")
+	dataConfigDir := fs.String("dir", defaultRootdir(), "Data/config directory")
+	secret := fs.String("keyring-secret", "", "Keyring secret (sets DEFRA_KEYRING_SECRET)")
+	query := fs.String("query", "", "GraphQL query/mutation")
 	varsStr := fs.String("vars", "", "JSON variables")
-	pretty  := fs.Bool("pretty", true, "Pretty-print JSON output")
-	reqTO   := fs.Duration("timeout", 10*time.Second, "Request timeout")
-	devMode := fs.Bool("dev", false, "enable development mode and verbose logging")
+	pretty := fs.Bool("pretty", true, "Pretty-print JSON output")
+	reqTO := fs.Duration("timeout", 10*time.Second, "Request timeout")
+	devMode := fs.Bool("dev", false, "Enable DefraDB development mode and verbose logging")
 	_ = fs.Parse(os.Args[1:])
 
 	// Keyring secret (first run convenience)
@@ -167,7 +167,7 @@ func main() {
 		q = strings.TrimSpace(string(b))
 	}
 	if q == "" {
-		fmt.Fprintln(os.Stderr, "no query provided; pass --query or pipe to stdin")
+		fmt.Fprintln(os.Stderr, "no query provided; pass -query or pipe to stdin")
 		os.Exit(2)
 	}
 
@@ -208,7 +208,7 @@ func main() {
 		dnode.WithDisableP2P(true),                    // local only
 		dnode.WithBadgerInMemory(false),               // persistent
 		dnode.WithStoreType(dnode.BadgerStore),
-		dnode.WithStorePath(resolveRootdir(*rootdir)), // data dir
+		dnode.WithStorePath(resolveRootdir(*dataConfigDir)), // data dir
 		dnode.WithLensRuntime(dnode.Wazero),           // pure-Go WASM runtime
 		dnode.WithEnableDevelopment(*devMode),         // toggle dev features/logging
 	)

--- a/defra-kv.go
+++ b/defra-kv.go
@@ -11,43 +11,15 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"syscall"
 	"time"
 
 	dclient "github.com/sourcenetwork/defradb/client"
-	dnode   "github.com/sourcenetwork/defradb/node"
+	dnode "github.com/sourcenetwork/defradb/node"
 	"github.com/rs/zerolog"
 )
-
-func defaultRootdir() string {
-	if cwd, err := os.Getwd(); err == nil {
-		return filepath.Join(cwd, ".defra-kv")
-	}
-	return ".defra-kv"
-}
-
-func expandHome(p string) string {
-	if strings.HasPrefix(p, "~/") {
-		if h, err := os.UserHomeDir(); err == nil {
-			return filepath.Join(h, p[2:])
-		}
-	}
-	return p
-}
-
-func resolveRootdir(p string) string {
-	p = expandHome(p)
-	if !filepath.IsAbs(p) {
-		if abs, err := filepath.Abs(p); err == nil {
-			p = abs
-		}
-	}
-	if err := os.MkdirAll(p, 0o755); err != nil {
-		log.Fatalf("create dataConfigDir: %v", err)
-	}
-	return p
-}
 
 // Single JSON-based KV schema with indexes where useful.
 const kvSchema = `
@@ -57,6 +29,25 @@ type KV {
 	updatedAt: DateTime @index
 }
 `
+
+var gqlNameRE = regexp.MustCompile(`^[_A-Za-z][_0-9A-Za-z]*$`)
+
+func defaultDataConfigDir() string {
+	if cwd, err := os.Getwd(); err == nil {
+		return filepath.Join(cwd, ".defra-kv")
+	}
+	return ".defra-kv"
+}
+
+func resolveRootdir(p string) string {
+	if p == "" || p == "." {
+		p = defaultDataConfigDir()
+	}
+	if err := os.MkdirAll(p, 0o755); err != nil {
+		log.Fatalf("create dataConfigDir: %v", err)
+	}
+	return p
+}
 
 func kvExists(ctx context.Context, n *dnode.Node) bool {
 	res := n.DB.ExecRequest(ctx, `query { __type(name: "KV") { name } }`)
@@ -109,32 +100,13 @@ func (s *fdSilencer) Mute() {
 	s.muted = true
 }
 
-func (s *fdSilencer) Restore() {
-	if !s.muted {
-		return
-	}
-	if s.origLogWriter != nil {
-		log.SetOutput(s.origLogWriter)
-	}
-	if s.origStdout != nil {
-		os.Stdout = s.origStdout
-	}
-	if s.origStderr != nil {
-		os.Stderr = s.origStderr
-	}
-	if s.devnull != nil {
-		_ = s.devnull.Close()
-	}
-	s.muted = false
-}
-
 func (s *fdSilencer) PrintlnOut(line string) {
 	if s != nil && s.origStdout != nil {
 		_, _ = s.origStdout.Write([]byte(line))
 		_, _ = s.origStdout.Write([]byte("\n"))
 		return
 	}
-	_, _ = os.Stdout.Write([]byte(line + "\n"))
+	fmt.Println(line)
 }
 
 func (s *fdSilencer) PrintlnErr(line string) {
@@ -143,7 +115,7 @@ func (s *fdSilencer) PrintlnErr(line string) {
 		_, _ = s.origStderr.Write([]byte("\n"))
 		return
 	}
-	_, _ = os.Stderr.Write([]byte(line + "\n"))
+	fmt.Fprintln(os.Stderr, line)
 }
 
 func die(s *fdSilencer, format string, a ...any) {
@@ -156,17 +128,72 @@ func die(s *fdSilencer, format string, a ...any) {
 	os.Exit(1)
 }
 
+// Convert a Go value (from JSON) into a GraphQL input literal string.
+// Supports: nil, bool, finite numbers, strings, arrays, and objects with GraphQL-Name keys.
+func toGraphQLLiteral(v any) (string, error) {
+	if v == nil {
+		return "null", nil
+	}
+	switch t := v.(type) {
+	case string:
+		b, _ := json.Marshal(t)
+		return string(b), nil
+	case bool:
+		if t {
+			return "true", nil
+		}
+		return "false", nil
+	case float64:
+		// JSON numbers decode to float64 and are finite by spec.
+		return fmt.Sprintf("%v", t), nil
+	case []any:
+		parts := make([]string, 0, len(t))
+		for _, e := range t {
+			lit, err := toGraphQLLiteral(e)
+			if err != nil {
+				return "", err
+			}
+			parts = append(parts, lit)
+		}
+		return "[" + strings.Join(parts, ", ") + "]", nil
+	case map[string]any:
+		parts := make([]string, 0, len(t))
+		for k, val := range t {
+			if !gqlNameRE.MatchString(k) {
+				return "", fmt.Errorf("invalid GraphQL key: %q", k)
+			}
+			lit, err := toGraphQLLiteral(val)
+			if err != nil {
+				return "", err
+			}
+			parts = append(parts, k+": "+lit)
+		}
+		return "{ " + strings.Join(parts, ", ") + " }", nil
+	default:
+		return "", fmt.Errorf("unsupported type in literal: %T", v)
+	}
+}
+
 func main() {
 	// Flags
 	fs := flag.NewFlagSet("defra-kv", flag.ExitOnError)
-	dataConfigDir := fs.String("dir", defaultRootdir(), "Data/config directory")
-	secret := fs.String("keyring-secret", "", "Keyring secret (sets DEFRA_KEYRING_SECRET)")
-	query := fs.String("query", "", "GraphQL query/mutation")
+	hasKey := fs.String("has", "", "Check key existence")
+	getKey := fs.String("get", "", "Get value by key")
+	setKey := fs.String("set", "", "Set/update value by key (value via stdin)")
+	removeKey := fs.String("remove", "", "Remove key/value")
 	varsStr := fs.String("vars", "", "JSON variables")
+	query := fs.String("query", "", "Raw GraphQL query/mutation")
 	pretty := fs.Bool("pretty", true, "Pretty-print JSON output")
 	reqTO := fs.Duration("timeout", 10*time.Second, "Request timeout")
+	dataConfigDir := fs.String("dir", defaultDataConfigDir(), "Data/config directory")
+	secret := fs.String("keyring-secret", "", "Keyring secret (sets DEFRA_KEYRING_SECRET)")
 	devMode := fs.Bool("dev", false, "Enable DefraDB development mode and verbose logging")
 	_ = fs.Parse(os.Args[1:])
+
+	// Determine mode: raw (-query) takes precedence over KV actions
+	hasAction := (
+		strings.TrimSpace(*query) == "" &&
+		(*setKey != "" || *getKey != "" || *hasKey != "" || *removeKey != ""))
 
 	// Keyring secret (first run convenience)
 	if *secret != "" {
@@ -176,25 +203,30 @@ func main() {
 		_ = os.Setenv("DEFRA_KEYRING_SECRET", "dev-dev-dev")
 	}
 
-	// Read query (flag or stdin)
-	q := strings.TrimSpace(*query)
-	if q == "" {
-		b, err := io.ReadAll(os.Stdin)
-		if err != nil {
-			log.Fatalf("read stdin: %v", err)
+	// Read query (flag or stdin) for raw mode only
+	var q string
+	if !hasAction {
+		q = strings.TrimSpace(*query)
+		if q == "" {
+			b, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				log.Fatalf("read stdin: %v", err)
+			}
+			q = strings.TrimSpace(string(b))
 		}
-		q = strings.TrimSpace(string(b))
-	}
-	if q == "" {
-		fmt.Fprintln(os.Stderr, "no query provided; pass -query or pipe to stdin")
-		os.Exit(2)
+		if q == "" {
+			fmt.Fprintln(os.Stderr, "no query provided; pass -query or pipe to stdin")
+			os.Exit(2)
+		}
 	}
 
-	// Variables (optional)
+	// Variables (optional) for raw mode
 	var vars map[string]any
-	if v := strings.TrimSpace(*varsStr); v != "" {
-		if err := json.Unmarshal([]byte(v), &vars); err != nil {
-			log.Fatalf("parse -vars: %v", err)
+	if !hasAction {
+		if v := strings.TrimSpace(*varsStr); v != "" {
+			if err := json.Unmarshal([]byte(v), &vars); err != nil {
+				log.Fatalf("parse -vars: %v", err)
+			}
 		}
 	}
 
@@ -223,13 +255,13 @@ func main() {
 	// Create and start the node (embedded, persistent Badger)
 	n, err := dnode.New(
 		ctx,
-		dnode.WithDisableAPI(true),                    // no HTTP server
-		dnode.WithDisableP2P(true),                    // local only
-		dnode.WithBadgerInMemory(false),               // persistent
+		dnode.WithDisableAPI(true),                          // no HTTP server
+		dnode.WithDisableP2P(true),                          // local only
+		dnode.WithBadgerInMemory(false),                     // persistent
 		dnode.WithStoreType(dnode.BadgerStore),
 		dnode.WithStorePath(resolveRootdir(*dataConfigDir)), // data dir
-		dnode.WithLensRuntime(dnode.Wazero),           // pure-Go WASM runtime
-		dnode.WithEnableDevelopment(*devMode),         // toggle dev features/logging
+		dnode.WithLensRuntime(dnode.Wazero),                 // pure-Go WASM runtime
+		dnode.WithEnableDevelopment(*devMode),               // toggle dev features/logging
 	)
 	if err != nil {
 		die(&sil, "dnode.New: %v", err)
@@ -241,6 +273,68 @@ func main() {
 
 	if err := ensureKV(ctx, n); err != nil {
 		die(&sil, "ensure KV schema: %v", err)
+	}
+
+	// Build canned KV queries if in action mode
+	if hasAction {
+		var b []byte
+		var err error
+		vars = map[string]any{}
+		if *setKey != "" {
+			// Read value JSON from stdin
+			b, err = io.ReadAll(os.Stdin)
+			if err != nil {
+				die(&sil, "read stdin value: %v", err)
+			}
+			valStr := strings.TrimSpace(string(b))
+			if valStr == "" {
+				die(&sil, "no value on stdin for -set")
+			}
+			var val any
+			if err := json.Unmarshal([]byte(valStr), &val); err != nil {
+				die(&sil, "invalid JSON on stdin: %v", err)
+			}
+			now := time.Now().UTC().Format(time.RFC3339Nano)
+			vars["now"] = now
+			vars["key"] = *setKey
+
+			// Note: this style (passing in `value` as an external variable)
+			// does not currently work, due to a bug in defra
+			//
+			// vars["value"] = val
+			// q = `mutation setKV($key:String!,$value:JSON!,$now:DateTime!) {
+			// 	upsert_KV(
+			// 		filter: { key: { _eq: $key } }
+			// 		create: { key: $key, value: $value, updatedAt: $now }
+			// 		update: { value: $value, updatedAt: $now }
+			// 	) { _docID }
+			// }`
+
+			lit, err := toGraphQLLiteral(val)
+			if err != nil {
+				die(&sil, "value cannot be inlined: %v", err)
+			}
+			q = fmt.Sprintf(
+				`mutation setKV($key:String!,$now:DateTime!) {
+					upsert_KV(
+						filter: { key: { _eq: $key } }
+						create: { key: $key, value: %s, updatedAt: $now }
+						update: { value: %s, updatedAt: $now }
+					) { _docID }
+				}`,
+				lit,
+				lit,
+			)
+		} else if *getKey != "" {
+			vars["key"] = *getKey
+			q = "query getKV($key:String!) { KV(filter:{ key:{ _eq:$key } }) { key value } }"
+		} else if *hasKey != "" {
+			vars["key"] = *hasKey
+			q = "query hasKV($key:String!) { KV(filter:{ key:{ _eq:$key } }) { _docID } }"
+		} else if *removeKey != "" {
+			vars["key"] = *removeKey
+			q = "mutation removeKV($key:String!) { delete_KV(filter:{ key:{ _eq:$key } }) { _docID } }"
+		}
 	}
 
 	reqCtx, cancel := context.WithTimeout(ctx, *reqTO)
@@ -262,16 +356,67 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Output JSON (with pretty-printing if specified)
-	var outBytes []byte
-	if *pretty {
-		outBytes, _ = json.MarshalIndent(map[string]any{"data": res.GQL.Data}, "", "  ")
+	// If using action mode, handle outputs/exit codes and return early
+	if hasAction {
+		m, _ := res.GQL.Data.(map[string]any)
+
+		// set
+		if *setKey != "" {
+			rows, _ := m["upsert_KV"].([]map[string]any)
+			if len(rows) > 0 {
+				os.Exit(0)
+			}
+			os.Exit(3)
+		}
+		// has
+		if *hasKey != "" {
+			rows, _ := m["KV"].([]map[string]any)
+			if len(rows) > 0 {
+				os.Exit(0)
+			}
+			os.Exit(3)
+		}
+		// del
+		if *removeKey != "" {
+			rows, _ := m["delete_KV"].([]map[string]any)
+			if len(rows) > 0 {
+				os.Exit(0)
+			}
+			os.Exit(3)
+		}
+		// get
+		if *getKey != "" {
+			rows, _ := m["KV"].([]map[string]any)
+
+			if len(rows) == 0 {
+				os.Exit(3)
+			}
+			doc := rows[0]
+			var outBytes []byte
+			if *pretty {
+				outBytes, _ = json.MarshalIndent(doc, "", "  ")
+			} else {
+				outBytes, _ = json.Marshal(doc)
+			}
+			if !*devMode {
+				sil.PrintlnOut(string(outBytes))
+			} else {
+				fmt.Println(string(outBytes))
+			}
+			os.Exit(0)
+		}
 	} else {
-		outBytes, _ = json.Marshal(map[string]any{"data": res.GQL.Data})
-	}
-	if !*devMode {
-		sil.PrintlnOut(string(outBytes))
-	} else {
-		fmt.Println(string(outBytes))
+		// Output JSON (with pretty-printing if specified) for raw mode
+		var outBytes []byte
+		if *pretty {
+			outBytes, _ = json.MarshalIndent(map[string]any{"data": res.GQL.Data}, "", "  ")
+		} else {
+			outBytes, _ = json.Marshal(map[string]any{"data": res.GQL.Data})
+		}
+		if !*devMode {
+			sil.PrintlnOut(string(outBytes))
+		} else {
+			fmt.Println(string(outBytes))
+		}
 	}
 }

--- a/defra-kv/main.go
+++ b/defra-kv/main.go
@@ -18,7 +18,6 @@ import (
 
 	dclient "github.com/sourcenetwork/defradb/client"
 	dnode "github.com/sourcenetwork/defradb/node"
-	"github.com/rs/zerolog"
 )
 
 // Single JSON-based KV schema with indexes where useful.
@@ -71,15 +70,13 @@ func ensureKV(ctx context.Context, n *dnode.Node) error {
 	return nil
 }
 
-type fdSilencer struct {
+type errSilencer struct {
 	muted         bool
 	devnull       *os.File
-	origStdout    *os.File
 	origStderr    *os.File
-	origLogWriter io.Writer
 }
 
-func (s *fdSilencer) Mute() {
+func (s *errSilencer) Mute() {
 	if s.muted {
 		return
 	}
@@ -88,28 +85,15 @@ func (s *fdSilencer) Mute() {
 		return
 	}
 	s.devnull = dn
-	s.origStdout = os.Stdout
 	s.origStderr = os.Stderr
-	s.origLogWriter = log.Writer()
 
-	// redirect global stdio and stdlib logger
-	os.Stdout = dn
+	// redirect global stderr
 	os.Stderr = dn
-	log.SetOutput(dn)
 
 	s.muted = true
 }
 
-func (s *fdSilencer) PrintlnOut(line string) {
-	if s != nil && s.origStdout != nil {
-		_, _ = s.origStdout.Write([]byte(line))
-		_, _ = s.origStdout.Write([]byte("\n"))
-		return
-	}
-	fmt.Println(line)
-}
-
-func (s *fdSilencer) PrintlnErr(line string) {
+func (s *errSilencer) PrintlnErr(line string) {
 	if s != nil && s.origStderr != nil {
 		_, _ = s.origStderr.Write([]byte(line))
 		_, _ = s.origStderr.Write([]byte("\n"))
@@ -118,7 +102,7 @@ func (s *fdSilencer) PrintlnErr(line string) {
 	fmt.Fprintln(os.Stderr, line)
 }
 
-func die(s *fdSilencer, format string, a ...any) {
+func die(s *errSilencer, format string, a ...any) {
 	msg := fmt.Sprintf(format, a...)
 	if s != nil {
 		s.PrintlnErr(msg)
@@ -189,21 +173,12 @@ func main() {
 	defer stop()
 
 	// Configure logging based on dev mode
-	var sil fdSilencer
+	var sil errSilencer
 	if !*devMode {
-		// Environment-driven loggers used by Defra & deps
-		_ = os.Setenv("DEFRA_LOG_LEVEL", "error")
-		_ = os.Setenv("CORELOG_LEVEL", "error") // if corelog is present
-		_ = os.Setenv("GOLOG_LOG_LEVEL", "error")
-
-		// zerolog global level
-		zerolog.SetGlobalLevel(zerolog.Disabled)
-
-		// mute stdio
+		_ = os.Setenv("LOG_LEVEL", "error")
 		sil.Mute()
 	} else {
-		// allow all logs through
-		zerolog.SetGlobalLevel(zerolog.InfoLevel)
+		_ = os.Setenv("LOG_LEVEL", "info")
 	}
 
 	// Create and start the node (embedded, persistent Badger)
@@ -234,6 +209,7 @@ func main() {
 		var b []byte
 		var err error
 		vars = map[string]any{}
+
 		if *setKey != "" {
 			// Read value JSON from stdin
 			b, err = io.ReadAll(os.Stdin)
@@ -327,17 +303,15 @@ func main() {
 				os.Exit(3)
 			}
 			doc := rows[0]
+
 			var outBytes []byte
 			if *pretty {
 				outBytes, _ = json.MarshalIndent(doc, "", "  ")
 			} else {
 				outBytes, _ = json.Marshal(doc)
 			}
-			if !*devMode {
-				sil.PrintlnOut(string(outBytes))
-			} else {
-				fmt.Println(string(outBytes))
-			}
+
+			fmt.Println(string(outBytes))
 			os.Exit(0)
 		}
 	} else {
@@ -348,10 +322,8 @@ func main() {
 		} else {
 			outBytes, _ = json.Marshal(map[string]any{"data": res.GQL.Data})
 		}
-		if !*devMode {
-			sil.PrintlnOut(string(outBytes))
-		} else {
-			fmt.Println(string(outBytes))
-		}
+
+		fmt.Println(string(outBytes))
+		os.Exit(0)
 	}
 }


### PR DESCRIPTION
**NOTE:** this isn't explicitly intended to actually add to the repo in its current form. It may be added or not, but that's not the goal at the moment. The point here is only code review.

This code was heavily generated by ChatGPT, so my goal is to get a sense of whether any parts of this code are good, bad, or neutral, and learn better how such a program should be coded.

----

This is a first-draft of a tool that satisfies the following design priorities:

- written in go
- acts as CLI tool
- embeds defradb in-process
- persists to disk (via Badger)
- creates a basic key-value type store (via an embedded `type` DDL)
- accepts parameters to set config, like keyring-secret and data-root
- primary input is a graphql-form query against the defra, such as `query { .. }` or `mutation { .. }`
- accepts query input either via stdin or `-query` CLI parameter
- includes a few helpful affordances such as home-dir expansion, default root dir, pretty JSON printing, etc.

now also includes KV actions via convenience parameters:

- `-has` checks if a key exists in the KV store
- `-get` looks up an entry by key name
- `-set` inserts (or updates) a key/value into the KV store
- `-remove` removes an entry by key name